### PR TITLE
Made broker protocol configurable

### DIFF
--- a/helpers/config.go
+++ b/helpers/config.go
@@ -10,11 +10,12 @@ import (
 type RiakCSIntegrationConfig struct {
 	services.Config
 
-	RiakCsHost   string `json:"riak_cs_host"`
-	RiakCsScheme string `json:"riak_cs_scheme"`
-	ServiceName  string `json:"service_name"`
-	PlanName     string `json:"plan_name"`
-	BrokerHost   string `json:"broker_host"`
+	RiakCsHost     string `json:"riak_cs_host"`
+	RiakCsScheme   string `json:"riak_cs_scheme"`
+	ServiceName    string `json:"service_name"`
+	PlanName       string `json:"plan_name"`
+	BrokerHost     string `json:"broker_host"`
+	BrokerProtocol string `json:"broker_protocol"`
 }
 
 func (c RiakCSIntegrationConfig) AppURI(appname string) string {
@@ -57,6 +58,10 @@ func ValidateConfig(config *RiakCSIntegrationConfig) error {
 
 	if config.RiakCsHost == "" {
 		return fmt.Errorf("Field 'riak_cs_host' must not be empty")
+	}
+
+	if config.BrokerProtocol == "" {
+		config.BrokerProtocol = "https"
 	}
 
 	return nil

--- a/riak-cs-service/route_register_test.go
+++ b/riak-cs-service/route_register_test.go
@@ -15,7 +15,7 @@ var _ = Describe("Riak CS Nodes Register a Route", func() {
 
 var _ = Describe("Riak Broker Registers a Route", func() {
 	It("Allows users to access the riak-cs broker using a url", func() {
-		endpointURL := "https://" + TestConfig.BrokerHost + "/v2/catalog"
+		endpointURL := TestConfig.BrokerProtocol + "://" + TestConfig.BrokerHost + "/v2/catalog"
 
 		// check for 401 because it means we reached the endpoint, but did not supply credentials.
 		// a failure would be a 404


### PR DESCRIPTION
Tests can now pass in environments where http is the only
protocol supported, as well as environments where https is the only
protocol supported.

Defaults to https.
